### PR TITLE
feat: map-zoom-derive-colors — closer map zoom, per-derive colored tr…

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -20,7 +20,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "1.0.0"
+        versionName "deriva_sonora_v1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/build-apk.sh
+++ b/build-apk.sh
@@ -56,7 +56,7 @@ timestamp=$(date +"%Y%m%d-%H%M%S")
 
 # Development feature keyword system - Recording Error Fixes
 # You can modify this keyword based on the current development focus
-DEV_KEYWORD="topbar-rebalance"
+DEV_KEYWORD="map-zoom-derive-colors"
 
 # Alternative keywords for different features:
 # DEV_KEYWORD="spatial-audio-nearby"   # For proximity-based spatial audio

--- a/src/components/AliasPrompt.jsx
+++ b/src/components/AliasPrompt.jsx
@@ -17,14 +17,14 @@ const AliasPrompt = ({ onSubmit, onCancel }) => {
       left: 0,
       right: 0,
       bottom: 0,
-      backgroundColor: 'rgba(0, 0, 0, 0.7)',
+      backgroundColor: 'rgb(20 50 20 / 65%)',
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
       zIndex: 10000
     }}>
       <div style={{
-        backgroundColor: 'white',
+        backgroundColor: '#f0f1ec',
         borderRadius: '12px',
         padding: '24px',
         maxWidth: '340px',
@@ -35,7 +35,7 @@ const AliasPrompt = ({ onSubmit, onCancel }) => {
           margin: '0 0 8px 0',
           fontSize: '18px',
           fontWeight: '600',
-          color: '#111827'
+          color: '#000000c9'
         }}>
           Tu nombre de caminante
         </h3>
@@ -57,7 +57,7 @@ const AliasPrompt = ({ onSubmit, onCancel }) => {
             style={{
               width: '100%',
               padding: '10px 12px',
-              border: '1px solid #D1D5DB',
+              border: '1px solid rgba(78,78,134,0.22)',
               borderRadius: '8px',
               fontSize: '16px',
               outline: 'none',
@@ -72,7 +72,7 @@ const AliasPrompt = ({ onSubmit, onCancel }) => {
               style={{
                 flex: 1,
                 padding: '10px',
-                backgroundColor: alias.trim() ? '#10B981' : '#9CA3AF',
+                backgroundColor: alias.trim() ? '#9dc04cd4' : '#9CA3AF',
                 color: 'white',
                 border: 'none',
                 borderRadius: '8px',
@@ -88,9 +88,9 @@ const AliasPrompt = ({ onSubmit, onCancel }) => {
               onClick={onCancel}
               style={{
                 padding: '10px 16px',
-                backgroundColor: 'white',
-                color: '#374151',
-                border: '1px solid #D1D5DB',
+                backgroundColor: '#f0f1ec',
+                color: 'rgb(1 9 2 / 84%)',
+                border: '1px solid rgba(78,78,134,0.22)',
                 borderRadius: '8px',
                 fontSize: '14px',
                 cursor: 'pointer'

--- a/src/components/BreadcrumbVisualization.jsx
+++ b/src/components/BreadcrumbVisualization.jsx
@@ -5,14 +5,14 @@ import L from 'leaflet';
 // Create custom icons for breadcrumb markers
 const createBreadcrumbIcon = (isMoving, audioLevel, size = 8) => {
   // Color based on movement and audio level
-  let color = '#3B82F6'; // blue (default)
+  let color = '#4e4e86'; // blue (default)
   
   if (isMoving) {
-    if (audioLevel > 0.7) color = '#EF4444'; // red (high audio, moving)
+    if (audioLevel > 0.7) color = '#c24a6e'; // red (high audio, moving)
     else if (audioLevel > 0.4) color = '#F59E0B'; // amber (medium audio, moving)
-    else color = '#10B981'; // green (low audio, moving)
+    else color = '#9dc04cd4'; // green (low audio, moving)
   } else {
-    if (audioLevel > 0.7) color = '#8B5CF6'; // purple (high audio, stationary)
+    if (audioLevel > 0.7) color = '#6a6aad'; // purple (high audio, stationary)
     else if (audioLevel > 0.4) color = '#EC4899'; // pink (medium audio, stationary)
     else color = '#6B7280'; // gray (low audio, stationary)
   }
@@ -40,7 +40,7 @@ const createDirectionIcon = (direction, size = 16) => {
     html: `<div style="
       width: ${size}px;
       height: ${size}px;
-      background-color: #1F2937;
+      background-color: #000000c9;
       border: 2px solid white;
       border-radius: 50%;
       display: flex;
@@ -110,11 +110,11 @@ const BreadcrumbVisualization = ({
           const audioLevel = breadcrumbs[index].audioLevel || 0;
           
           if (isMoving) {
-            if (audioLevel > 0.7) return '#EF4444'; // red
+            if (audioLevel > 0.7) return '#c24a6e'; // red
             if (audioLevel > 0.4) return '#F59E0B'; // amber
-            return '#10B981'; // green
+            return '#9dc04cd4'; // green
           } else {
-            if (audioLevel > 0.7) return '#8B5CF6'; // purple
+            if (audioLevel > 0.7) return '#6a6aad'; // purple
             if (audioLevel > 0.4) return '#EC4899'; // pink
             return '#6B7280'; // gray
           }

--- a/src/components/DetailView.jsx
+++ b/src/components/DetailView.jsx
@@ -8,7 +8,7 @@ class DetailView extends React.Component {
       var point = this.props.point.properties
 
       innerInfo =
-      <div className="absolute w-full p-2 pt-4 md:pt-16 pin-b pin-l gradient flex items-center justify-center" style={{ height: "50%", backgroundColor: "rgba(0, 0, 0, 0.85)"}}>
+      <div className="absolute w-full p-2 pt-4 md:pt-16 pin-b pin-l gradient flex items-center justify-center" style={{ height: "50%", backgroundColor: "rgb(20 50 20 / 85%)"}}>
         <i onClick={() => this.props.getPreviousRecording(this.props.point)} className="fas fa-chevron-left text-4xl text-white hover:text-black cursor-pointer m-2 md:m-12"></i>
         <div className="max-w-xl flex flex-col sm:flex-row flex items-start md:items-center h-full">
           <div className="h-1/2 p-4 text-black leading-normal pb-3 font-sans overflow-auto" style={{ flex:2 }}>

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -51,7 +51,7 @@ const LandingPage = ({ onModeSelect, hasRequestedPermission, setHasRequestedPerm
       boxSizing: 'border-box'
     }}>
       <div style={{
-        backgroundColor: 'rgba(0, 0, 0, 0.07)',
+        backgroundColor: 'rgb(20 50 20 / 35%)',
         borderRadius: '16px',
         padding: '30px',
         maxWidth: '500px',
@@ -115,7 +115,7 @@ const LandingPage = ({ onModeSelect, hasRequestedPermission, setHasRequestedPerm
                 alignItems: 'center',
                 justifyContent: 'center',
                 gap: '12px',
-                backgroundColor: 'rgba(16, 185, 129, 0.8)',
+                backgroundColor: 'rgba(157, 192, 76, 0.83)',
                 color: 'white',
                 border: 'none',
                 borderRadius: '8px',
@@ -125,8 +125,8 @@ const LandingPage = ({ onModeSelect, hasRequestedPermission, setHasRequestedPerm
                 cursor: 'pointer',
                 transition: 'all 0.2s',
               }}
-              onMouseOver={(e) => e.currentTarget.style.backgroundColor = 'rgba(16, 185, 129, 1)'}
-              onMouseOut={(e) => e.currentTarget.style.backgroundColor = 'rgba(16, 185, 129, 0.8)'}
+              onMouseOver={(e) => e.currentTarget.style.backgroundColor = 'rgba(157, 192, 76, 1)'}
+              onMouseOut={(e) => e.currentTarget.style.backgroundColor = 'rgba(157, 192, 76, 0.83)'}
             >
               Entrar
             </button>
@@ -139,7 +139,7 @@ const LandingPage = ({ onModeSelect, hasRequestedPermission, setHasRequestedPerm
               display: 'flex',
               alignItems: 'center',
               gap: '12px',
-              backgroundColor: 'rgba(16, 185, 129, 0.8)',
+              backgroundColor: 'rgba(157, 192, 76, 0.83)',
               color: 'white',
               border: 'none',
               borderRadius: '8px',
@@ -150,8 +150,8 @@ const LandingPage = ({ onModeSelect, hasRequestedPermission, setHasRequestedPerm
               transition: 'all 0.2s',
               textAlign: 'left'
             }}
-            onMouseOver={(e) => e.currentTarget.style.backgroundColor = 'rgba(16, 185, 129, 1)'}
-            onMouseOut={(e) => e.currentTarget.style.backgroundColor = 'rgba(16, 185, 129, 0.8)'}
+            onMouseOver={(e) => e.currentTarget.style.backgroundColor = 'rgba(157, 192, 76, 1)'}
+            onMouseOut={(e) => e.currentTarget.style.backgroundColor = 'rgba(157, 192, 76, 0.83)'}
           >
             <div style={{
               backgroundColor: 'rgba(255, 255, 255, 0.2)',
@@ -179,7 +179,7 @@ const LandingPage = ({ onModeSelect, hasRequestedPermission, setHasRequestedPerm
                 display: 'flex',
                 alignItems: 'center',
                 gap: '12px',
-                backgroundColor: 'rgba(59, 130, 246, 0.8)',
+                backgroundColor: 'rgba(78, 78, 134, 0.84)',
                 color: 'white',
                 border: 'none',
                 borderRadius: '8px',
@@ -190,8 +190,8 @@ const LandingPage = ({ onModeSelect, hasRequestedPermission, setHasRequestedPerm
                 transition: 'all 0.2s',
                 textAlign: 'left'
               }}
-              onMouseOver={(e) => e.currentTarget.style.backgroundColor = 'rgba(59, 130, 246, 1)'}
-              onMouseOut={(e) => e.currentTarget.style.backgroundColor = 'rgba(59, 130, 246, 0.8)'}
+              onMouseOver={(e) => e.currentTarget.style.backgroundColor = 'rgba(78, 78, 134, 1)'}
+              onMouseOut={(e) => e.currentTarget.style.backgroundColor = 'rgba(78, 78, 134, 0.84)'}
             >
               <div style={{
                 backgroundColor: 'rgba(255, 255, 255, 0.2)',
@@ -212,7 +212,7 @@ const LandingPage = ({ onModeSelect, hasRequestedPermission, setHasRequestedPerm
             </button>
           ) : (
             <div style={{
-              backgroundColor: 'rgba(255, 255, 255, 0.9)',
+              backgroundColor: 'rgba(220, 225, 235, 0.92)',
               borderRadius: '12px',
               padding: '20px',
               boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)'
@@ -220,7 +220,7 @@ const LandingPage = ({ onModeSelect, hasRequestedPermission, setHasRequestedPerm
               <h3 style={{
                 fontSize: '16px',
                 fontWeight: '600',
-                color: '#1F2937',
+                color: '#000000c9',
                 marginTop: '0',
                 marginBottom: '16px'
               }}>
@@ -238,18 +238,18 @@ const LandingPage = ({ onModeSelect, hasRequestedPermission, setHasRequestedPerm
                   style={{
                     width: '100%',
                     padding: '12px 16px',
-                    border: passwordError ? '2px solid #EF4444' : '2px solid #E5E7EB',
+                    border: passwordError ? '2px solid #c24a6e' : '2px solid rgba(78,78,134,0.15)',
                     borderRadius: '8px',
                     fontSize: '14px',
                     outline: 'none',
                     marginBottom: '8px',
                     boxSizing: 'border-box',
-                    backgroundColor: '#fff'
+                    backgroundColor: '#f0f1ec'
                   }}
                 />
                 {passwordError && (
                   <div style={{
-                    color: '#EF4444',
+                    color: '#c24a6e',
                     fontSize: '12px',
                     marginTop: '4px',
                     marginBottom: '12px'
@@ -266,7 +266,7 @@ const LandingPage = ({ onModeSelect, hasRequestedPermission, setHasRequestedPerm
                     type="submit"
                     style={{
                       flex: 1,
-                      backgroundColor: '#3B82F6',
+                      backgroundColor: '#4e4e86',
                       color: 'white',
                       border: 'none',
                       borderRadius: '6px',
@@ -276,8 +276,8 @@ const LandingPage = ({ onModeSelect, hasRequestedPermission, setHasRequestedPerm
                       cursor: 'pointer',
                       transition: 'background-color 0.2s'
                     }}
-                    onMouseOver={(e) => e.currentTarget.style.backgroundColor = '#2563EB'}
-                    onMouseOut={(e) => e.currentTarget.style.backgroundColor = '#3B82F6'}
+                    onMouseOver={(e) => e.currentTarget.style.backgroundColor = '#3d3d6b'}
+                    onMouseOut={(e) => e.currentTarget.style.backgroundColor = '#4e4e86'}
                   >
                     Ingresar
                   </button>
@@ -343,9 +343,9 @@ const LandingPage = ({ onModeSelect, hasRequestedPermission, setHasRequestedPerm
           bottom: '50%',
           left: '50%',
           transform: 'translate(-50%, 50%)',
-          backgroundColor: '#ffffffbf',
+          backgroundColor: 'rgba(220,225,235,0.78)',
           borderRadius: '16px',
-          boxShadow: 'rgb(157 58 58 / 30%) 0px 10px 30px',
+          boxShadow: 'rgba(78,78,134,0.25) 0px 10px 30px',
           backdropFilter: 'blur(12px)',
           width: '90%',
           maxWidth: '400px',
@@ -374,7 +374,7 @@ const LandingPage = ({ onModeSelect, hasRequestedPermission, setHasRequestedPerm
             ✕
           </button>
 
-          <div style={{ fontSize: '13px', lineHeight: '1.6', color: '#2D3748' }}>
+          <div style={{ fontSize: '13px', lineHeight: '1.6', color: 'rgb(1 9 2 / 84%)' }}>
             <p style={{ marginTop: 0, marginBottom: '14px', fontSize: '13px' }}>
               <strong>SoundWalk</strong> es un dispositivo para crear mapas sonoros comunitarios.
               Genera derivas sonoras que capturan la diversidad acustica y facilitan

--- a/src/components/SessionHistoryPanel.jsx
+++ b/src/components/SessionHistoryPanel.jsx
@@ -59,9 +59,9 @@ const SessionHistoryPanel = ({ onClose, onViewSession, onExportSession, visibleS
       bottom: '190px',
       left: '50%',
       transform: 'translateX(-50%)',
-      backgroundColor: '#ffffffbf',
+      backgroundColor: 'rgba(220,225,235,0.78)',
       borderRadius: '16px',
-      boxShadow: 'rgb(157 58 58 / 30%) 0px 10px 30px',
+      boxShadow: 'rgba(78,78,134,0.25) 0px 10px 30px',
       width: '90%',
       maxWidth: '400px',
       maxHeight: '50vh',
@@ -80,7 +80,7 @@ const SessionHistoryPanel = ({ onClose, onViewSession, onExportSession, visibleS
           borderBottom: '1px solid rgba(0,0,0,0.08)',
           position: 'relative'
         }}>
-          <h3 style={{ margin: 0, fontSize: '16px', fontWeight: '600', color: '#111827' }}>
+          <h3 style={{ margin: 0, fontSize: '16px', fontWeight: '600', color: '#000000c9' }}>
             Capas de Derivas
           </h3>
           <button
@@ -122,7 +122,7 @@ const SessionHistoryPanel = ({ onClose, onViewSession, onExportSession, visibleS
                     padding: '12px',
                     marginBottom: '8px',
                     borderRadius: '10px',
-                    border: '1px solid #E5E7EB',
+                    border: '1px solid rgba(78,78,134,0.15)',
                     borderLeft: `4px solid ${color}`,
                     backgroundColor: visible ? '#FAFAFA' : '#F3F4F6',
                     opacity: visible ? 1 : 0.6,
@@ -131,7 +131,7 @@ const SessionHistoryPanel = ({ onClose, onViewSession, onExportSession, visibleS
                 >
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
                     <div style={{ flex: 1 }}>
-                      <div style={{ fontSize: '15px', fontWeight: '500', color: '#111827', marginBottom: '4px' }}>
+                      <div style={{ fontSize: '15px', fontWeight: '500', color: '#000000c9', marginBottom: '4px' }}>
                         {session.title || 'Deriva sin título'}
                       </div>
                       <div style={{ fontSize: '12px', color: '#6B7280', marginBottom: '6px' }}>
@@ -160,8 +160,8 @@ const SessionHistoryPanel = ({ onClose, onViewSession, onExportSession, visibleS
                         onClick={() => onToggleVisibility && onToggleVisibility(session.sessionId)}
                         title={visible ? 'Ocultar en mapa' : 'Mostrar en mapa'}
                         style={{
-                          background: visible ? '#10B981' : 'none',
-                          border: visible ? 'none' : '1px solid #D1D5DB',
+                          background: visible ? '#9dc04cd4' : 'none',
+                          border: visible ? 'none' : '1px solid rgba(78,78,134,0.22)',
                           borderRadius: '6px',
                           padding: '6px',
                           cursor: 'pointer',
@@ -175,12 +175,12 @@ const SessionHistoryPanel = ({ onClose, onViewSession, onExportSession, visibleS
                         onClick={() => setPlayModePickerFor(showingModePicker ? null : session.sessionId)}
                         title="Reproducir deriva"
                         style={{
-                          background: showingModePicker ? '#3B82F6' : 'none',
-                          border: showingModePicker ? 'none' : '1px solid #D1D5DB',
+                          background: showingModePicker ? '#4e4e86' : 'none',
+                          border: showingModePicker ? 'none' : '1px solid rgba(78,78,134,0.22)',
                           borderRadius: '6px',
                           padding: '6px',
                           cursor: 'pointer',
-                          color: showingModePicker ? 'white' : '#374151'
+                          color: showingModePicker ? 'white' : 'rgb(1 9 2 / 84%)'
                         }}
                       >
                         <Play size={14} />
@@ -190,11 +190,11 @@ const SessionHistoryPanel = ({ onClose, onViewSession, onExportSession, visibleS
                         title="Exportar ZIP"
                         style={{
                           background: 'none',
-                          border: '1px solid #D1D5DB',
+                          border: '1px solid rgba(78,78,134,0.22)',
                           borderRadius: '6px',
                           padding: '6px',
                           cursor: 'pointer',
-                          color: '#374151'
+                          color: 'rgb(1 9 2 / 84%)'
                         }}
                       >
                         <Download size={14} />
@@ -204,7 +204,7 @@ const SessionHistoryPanel = ({ onClose, onViewSession, onExportSession, visibleS
                           <button
                             onClick={() => handleDelete(session.sessionId)}
                             style={{
-                              background: '#EF4444',
+                              background: '#c24a6e',
                               border: 'none',
                               borderRadius: '6px',
                               padding: '6px 8px',
@@ -219,11 +219,11 @@ const SessionHistoryPanel = ({ onClose, onViewSession, onExportSession, visibleS
                             onClick={() => setConfirmDeleteId(null)}
                             style={{
                               background: 'none',
-                              border: '1px solid #D1D5DB',
+                              border: '1px solid rgba(78,78,134,0.22)',
                               borderRadius: '6px',
                               padding: '6px 8px',
                               cursor: 'pointer',
-                              color: '#374151',
+                              color: 'rgb(1 9 2 / 84%)',
                               fontSize: '11px'
                             }}
                           >
@@ -236,11 +236,11 @@ const SessionHistoryPanel = ({ onClose, onViewSession, onExportSession, visibleS
                           title="Eliminar"
                           style={{
                             background: 'none',
-                            border: '1px solid #D1D5DB',
+                            border: '1px solid rgba(78,78,134,0.22)',
                             borderRadius: '6px',
                             padding: '6px',
                             cursor: 'pointer',
-                            color: '#EF4444'
+                            color: '#c24a6e'
                           }}
                         >
                           <Trash2 size={14} />
@@ -254,7 +254,7 @@ const SessionHistoryPanel = ({ onClose, onViewSession, onExportSession, visibleS
                     <div style={{
                       marginTop: '10px',
                       paddingTop: '10px',
-                      borderTop: '1px solid #E5E7EB',
+                      borderTop: '1px solid rgba(78,78,134,0.15)',
                       display: 'flex',
                       gap: '6px',
                       flexWrap: 'wrap'
@@ -272,7 +272,7 @@ const SessionHistoryPanel = ({ onClose, onViewSession, onExportSession, visibleS
                           }}
                           style={{
                             padding: '6px 12px',
-                            backgroundColor: '#3B82F6',
+                            backgroundColor: '#4e4e86',
                             color: 'white',
                             border: 'none',
                             borderRadius: '6px',

--- a/src/components/SharedMarkerUtils.js
+++ b/src/components/SharedMarkerUtils.js
@@ -8,10 +8,10 @@ export function createDurationCircleIcon(duration) {
   const normalizedDuration = Math.max(minDuration, Math.min(maxDuration, duration || 10));
   const radius = minRadius + ((normalizedDuration - minDuration) / (maxDuration - minDuration)) * (maxRadius - minRadius);
 
-  let color = '#3B82F6'; // blue
-  if (normalizedDuration < 30) color = '#3B82F6';
-  else if (normalizedDuration < 60) color = '#10B981';
-  else color = '#EF4444';
+  let color = '#4e4e86'; // blue
+  if (normalizedDuration < 30) color = '#4e4e86';
+  else if (normalizedDuration < 60) color = '#9dc04cd4';
+  else color = '#c24a6e';
 
   return L.divIcon({
     className: 'duration-circle-marker',

--- a/src/components/SharedTopBar.jsx
+++ b/src/components/SharedTopBar.jsx
@@ -152,18 +152,18 @@ class SharedTopBar extends React.Component {
     const locationStatus = this.props.userLocation ? 'active' : 'inactive';
 
     // Determine mic button color
-    let micColor = '#ef4444'; // red (ready)
+    let micColor = '#c24a6e'; // red (ready)
     if (this.props.isRecording) micColor = '#F59E42'; // amber (recording)
     if (this.props.isMicDisabled) micColor = '#9CA3AF'; // gray (disabled)
 
     // Unified shadow system
-    const unifiedShadow = '0 4px 12px rgba(0,0,0,0.15), 0 2px 6px rgba(0,0,0,0.1)';
-    const unifiedShadowHover = '0 6px 20px rgba(0,0,0,0.2), 0 3px 10px rgba(0,0,0,0.15)';
+    const unifiedShadow = '0 4px 12px rgba(78,78,134,0.18), 0 2px 6px rgba(0,0,0,0.1)';
+    const unifiedShadowHover = '0 6px 20px rgba(0,0,0,0.2), 0 3px 10px rgba(78,78,134,0.18)';
     
     // Common button style for bottom controls
     const bottomButtonStyle = {
       padding: '12px 16px',
-      background: 'rgba(255, 255, 255, 0.80)',
+      background: 'rgba(201,206,177,0.75)',
       borderRadius: '12px',
       boxShadow: unifiedShadow,
       display: 'flex',
@@ -175,7 +175,7 @@ class SharedTopBar extends React.Component {
       backdropFilter: 'blur(10px)',
       fontSize: '14px',
       fontWeight: '600',
-      color: '#1F2937',
+      color: '#000000c9',
       minWidth: 'auto'
     };
 
@@ -223,8 +223,8 @@ class SharedTopBar extends React.Component {
                   justifyContent: 'center',
                   minWidth: '36px',
                   flexShrink: 0,
-                  backgroundColor: this.props.showBreadcrumbs && this.props.breadcrumbVisualization === 'line' ? '#3B82F6' : 'rgba(255, 255, 255, 0.85)',
-                  color: this.props.showBreadcrumbs && this.props.breadcrumbVisualization === 'line' ? 'white' : '#1F2937'
+                  backgroundColor: this.props.showBreadcrumbs && this.props.breadcrumbVisualization === 'line' ? '#4e4e86' : 'rgba(201,206,177,0.50)',
+                  color: this.props.showBreadcrumbs && this.props.breadcrumbVisualization === 'line' ? 'white' : '#000000c9'
                 }}
                 title="Vista de Línea"
               >
@@ -248,8 +248,8 @@ class SharedTopBar extends React.Component {
                   justifyContent: 'center',
                   minWidth: '36px',
                   flexShrink: 0,
-                  backgroundColor: this.props.showBreadcrumbs && this.props.breadcrumbVisualization === 'heatmap' ? '#EF4444' : 'rgba(255, 255, 255, 0.85)',
-                  color: this.props.showBreadcrumbs && this.props.breadcrumbVisualization === 'heatmap' ? 'white' : '#1F2937'
+                  backgroundColor: this.props.showBreadcrumbs && this.props.breadcrumbVisualization === 'heatmap' ? '#c24a6e' : 'rgba(201,206,177,0.50)',
+                  color: this.props.showBreadcrumbs && this.props.breadcrumbVisualization === 'heatmap' ? 'white' : '#000000c9'
                 }}
                 title="Vista de Mapa de Calor"
               >
@@ -273,8 +273,8 @@ class SharedTopBar extends React.Component {
                   justifyContent: 'center',
                   minWidth: '36px',
                   flexShrink: 0,
-                  backgroundColor: this.props.showBreadcrumbs && this.props.breadcrumbVisualization === 'animated' ? '#8B5CF6' : 'rgba(255, 255, 255, 0.85)',
-                  color: this.props.showBreadcrumbs && this.props.breadcrumbVisualization === 'animated' ? 'white' : '#1F2937'
+                  backgroundColor: this.props.showBreadcrumbs && this.props.breadcrumbVisualization === 'animated' ? '#6a6aad' : 'rgba(201,206,177,0.50)',
+                  color: this.props.showBreadcrumbs && this.props.breadcrumbVisualization === 'animated' ? 'white' : '#000000c9'
                 }}
                 title="Reproducción Animada"
               >
@@ -313,9 +313,10 @@ class SharedTopBar extends React.Component {
                   padding: '8px 14px',
                   fontSize: '13px',
                   height: '40px',
-                  backgroundColor: '#10B981',
+                  backgroundColor: '#9dc04c',
                   color: 'white',
                   flexShrink: 0,
+                  boxShadow: '0 4px 12px rgba(157,192,76,0.5), 0 0 0 3px rgba(157,192,76,0.25)',
                 }}
                 title="Iniciar Deriva Sonora"
               >
@@ -372,7 +373,7 @@ class SharedTopBar extends React.Component {
                   padding: '8px 12px',
                   fontSize: '13px',
                   height: '40px',
-                  backgroundColor: '#6B7280',
+                  backgroundColor: '#c24a6e99',
                   color: 'white',
                   flexShrink: 0,
                 }}
@@ -400,7 +401,7 @@ class SharedTopBar extends React.Component {
               gap: '8px',
               cursor: 'pointer',
               transition: 'opacity 0.3s ease',
-              opacity: this.state.derivePaused ? 0.35 : 1,
+              opacity: this.state.derivePaused ? 0.65 : 1,
             }}
           >
             <span style={{
@@ -417,8 +418,8 @@ class SharedTopBar extends React.Component {
               <MapPin size={13} />
               {this._formatDistance(this.state.deriveDistance)}
               <span style={{ opacity: 0.4 }}>&middot;</span>
-              <Mic size={13} style={{ color: '#10B981' }} />
-              <span style={{ color: '#10B981', fontWeight: '700' }}>{this.props.walkSession.recordingIds?.length || 0}</span>
+              <Mic size={13} style={{ color: '#9dc04cd4' }} />
+              <span style={{ color: '#9dc04cd4', fontWeight: '700' }}>{this.props.walkSession.recordingIds?.length || 0}</span>
             </span>
             <button
               onClick={(e) => { e.stopPropagation(); this._toggleDerivePause(); }}
@@ -430,8 +431,8 @@ class SharedTopBar extends React.Component {
                 height: '36px',
                 justifyContent: 'center',
                 minWidth: '36px',
-                backgroundColor: this.state.derivePaused ? '#F59E42' : 'rgba(255, 255, 255, 0.85)',
-                color: this.state.derivePaused ? 'white' : '#1F2937',
+                backgroundColor: this.state.derivePaused ? '#F59E42' : 'rgba(201,206,177,0.50)',
+                color: this.state.derivePaused ? 'white' : '#000000c9',
               }}
               title={this.state.derivePaused ? 'Reanudar Deriva' : 'Pausar Deriva'}
             >
@@ -454,7 +455,7 @@ class SharedTopBar extends React.Component {
             maxHeight: '44px',
             fontSize: '13px',
             padding: '0 8px',
-            background: 'rgba(255,255,255,0.95)',
+            background: 'rgba(220,225,235,0.92)',
             borderRadius: '12px',
             boxShadow: unifiedShadow,
             display: 'flex',
@@ -465,7 +466,7 @@ class SharedTopBar extends React.Component {
             overflow: 'visible',
             border: 'none',
             fontWeight: '600',
-            color: '#1F2937',
+            color: '#000000c9',
             boxSizing: 'border-box'
           }}
         >
@@ -503,7 +504,7 @@ class SharedTopBar extends React.Component {
           <button
             onClick={this.toggleLayerInfo}
             style={{
-              background: 'rgba(255, 255, 255, 0.9)',
+              background: 'rgba(220,225,235,0.92)',
               border: '2px solid rgba(0,0,0,0.1)',
               borderRadius: '50%',
               padding: '6px',
@@ -525,7 +526,7 @@ class SharedTopBar extends React.Component {
             }}
             title="Guía de Uso"
           >
-            <Info size={20} style={{ color: '#3B82F6' }} />
+            <Info size={20} style={{ color: '#4e4e86' }} />
           </button>
 
           {/* GPS/Recenter Button */}
@@ -591,7 +592,7 @@ class SharedTopBar extends React.Component {
                 }}
                 title="Seleccionar Capa de Mapa"
               >
-                <Layers size={20} style={{ color: '#1F2937' }} />
+                <Layers size={20} style={{ color: '#000000c9' }} />
               </button>
               {this.state.layerMenuOpen && (
                 <div style={{
@@ -600,7 +601,7 @@ class SharedTopBar extends React.Component {
                   left: '50%',
                   transform: 'translateX(-50%)',
                   marginTop: '6px',
-                  background: 'rgba(255, 255, 255, 0.95)',
+                  background: 'rgba(220,225,235,0.92)',
                   borderRadius: '12px',
                   boxShadow: unifiedShadow,
                   backdropFilter: 'blur(10px)',
@@ -615,6 +616,8 @@ class SharedTopBar extends React.Component {
                     { key: 'CartoDB', label: 'Carto', title: 'CartoDB Positron' },
                     { key: 'OSMHumanitarian', label: 'Humanitarian', title: 'OSM Humanitario' },
                     { key: 'StadiaSatellite', label: 'Satélite', title: 'Stadia Satellite' },
+                    { key: 'EsriWorldImagery', label: 'Esri Img', title: 'Esri World Imagery (Satelite)' },
+                    { key: 'CyclOSM', label: 'CyclOSM', title: 'CyclOSM (Ciclovias / Topografia)' },
                   ].map(layer => (
                     <button
                       key={layer.key}
@@ -627,18 +630,18 @@ class SharedTopBar extends React.Component {
                         cursor: 'pointer',
                         fontSize: '13px',
                         fontWeight: '600',
-                        color: this.props.currentLayer === layer.key ? '#10B981' : '#1F2937',
-                        backgroundColor: this.props.currentLayer === layer.key ? 'rgba(16, 185, 129, 0.1)' : 'transparent',
+                        color: this.props.currentLayer === layer.key ? '#9dc04cd4' : '#000000c9',
+                        backgroundColor: this.props.currentLayer === layer.key ? 'rgba(157,192,76,0.12)' : 'transparent',
                         display: 'flex',
                         alignItems: 'center',
                         justifyContent: 'center',
                         transition: 'all 0.2s ease'
                       }}
                       onMouseEnter={(e) => {
-                        e.target.style.backgroundColor = this.props.currentLayer === layer.key ? 'rgba(16, 185, 129, 0.15)' : 'rgba(0,0,0,0.05)';
+                        e.target.style.backgroundColor = this.props.currentLayer === layer.key ? 'rgba(157,192,76,0.18)' : 'rgba(0,0,0,0.05)';
                       }}
                       onMouseLeave={(e) => {
-                        e.target.style.backgroundColor = this.props.currentLayer === layer.key ? 'rgba(16, 185, 129, 0.1)' : 'transparent';
+                        e.target.style.backgroundColor = this.props.currentLayer === layer.key ? 'rgba(157,192,76,0.12)' : 'transparent';
                       }}
                       title={layer.title}
                     >
@@ -666,7 +669,7 @@ class SharedTopBar extends React.Component {
               }}
               title="Importar Tracklog"
             >
-              <Download size={20} style={{ color: '#1F2937' }} />
+              <Download size={20} style={{ color: '#000000c9' }} />
             </button>
           )}
 
@@ -745,7 +748,7 @@ class SharedTopBar extends React.Component {
             >
               ✕
             </button>
-            <div style={{ fontSize: '13px', lineHeight: '1.6', color: '#2D3748' }}>
+            <div style={{ fontSize: '13px', lineHeight: '1.6', color: 'rgb(1 9 2 / 84%)' }}>
               <div style={{ marginBottom: '14px' }}>
                 <div style={{ fontWeight: '700', fontSize: '14px', marginBottom: '6px' }}>Barra superior</div>
                 <div style={{ display: 'grid', gridTemplateColumns: 'auto 1fr', gap: '4px 10px', fontSize: '12px' }}>
@@ -784,6 +787,19 @@ class SharedTopBar extends React.Component {
               }}>
                 Pellizca para zoom. Toca marcadores para escuchar. Cada grabacion incluye coordenadas, hora y metadatos.
               </div>
+              <div style={{ marginTop: '14px' }}>
+                <div style={{ fontWeight: '700', fontSize: '14px', marginBottom: '6px' }}>Creditos</div>
+                <div style={{ display: 'grid', gridTemplateColumns: 'auto 1fr', gap: '4px 10px', fontSize: '11px', color: '#6B7280' }}>
+                  <span>Leaflet</span><span>leafletjs.com</span>
+                  <span>OpenStreetMap</span><span>openstreetmap.org</span>
+                  <span>OpenTopoMap</span><span>opentopomap.org</span>
+                  <span>CARTO</span><span>carto.com</span>
+                  <span>HOT</span><span>hotosm.org</span>
+                  <span>Stadia Maps</span><span>stadiamaps.com</span>
+                  <span>Esri</span><span>arcgis.com</span>
+                  <span>CyclOSM</span><span>cyclosm.org</span>
+                </div>
+              </div>
             </div>
           </div>
         )}
@@ -810,9 +826,9 @@ class SharedTopBar extends React.Component {
             bottom: '190px',
             left: '50%',
             transform: 'translateX(-50%)',
-            backgroundColor: '#ffffffbf',
+            backgroundColor: 'rgba(220,225,235,0.78)',
             borderRadius: '16px',
-            boxShadow: 'rgb(157 58 58 / 30%) 0px 10px 30px',
+            boxShadow: 'rgba(78,78,134,0.25) 0px 10px 30px',
             padding: '20px',
             minWidth: '300px',
             maxWidth: '400px',
@@ -852,7 +868,7 @@ class SharedTopBar extends React.Component {
                   alignItems: 'center',
                   gap: '6px',
                   padding: '8px 20px',
-                  backgroundColor: this.state.derivePaused ? '#F59E42' : '#3B82F6',
+                  backgroundColor: this.state.derivePaused ? '#F59E42' : '#4e4e86',
                   color: 'white',
                   border: 'none',
                   borderRadius: '8px',
@@ -875,7 +891,7 @@ class SharedTopBar extends React.Component {
               style={{
                 width: '100%',
                 padding: '10px 12px',
-                border: '1px solid #D1D5DB',
+                border: '1px solid rgba(78,78,134,0.22)',
                 borderRadius: '8px',
                 fontSize: '14px',
                 outline: 'none',
@@ -894,7 +910,7 @@ class SharedTopBar extends React.Component {
                 style={{
                   flex: 1,
                   padding: '10px',
-                  backgroundColor: '#10B981',
+                  backgroundColor: '#9dc04cd4',
                   color: 'white',
                   border: 'none',
                   borderRadius: '8px',
@@ -910,8 +926,8 @@ class SharedTopBar extends React.Component {
                 style={{
                   padding: '10px 16px',
                   backgroundColor: 'white',
-                  color: '#374151',
-                  border: '1px solid #D1D5DB',
+                  color: 'rgb(1 9 2 / 84%)',
+                  border: '1px solid rgba(78,78,134,0.22)',
                   borderRadius: '8px',
                   fontSize: '14px',
                   cursor: 'pointer'

--- a/src/components/TracklogImportModal.jsx
+++ b/src/components/TracklogImportModal.jsx
@@ -143,9 +143,9 @@ const TracklogImportModal = ({ isVisible, onClose, onImportComplete }) => {
       bottom: '190px',
       left: '50%',
       transform: 'translateX(-50%)',
-      backgroundColor: '#ffffffbf',
+      backgroundColor: 'rgba(220,225,235,0.78)',
       borderRadius: '16px',
-      boxShadow: 'rgb(157 58 58 / 30%) 0px 10px 30px',
+      boxShadow: 'rgba(78,78,134,0.25) 0px 10px 30px',
       width: '90%',
       maxWidth: '400px',
       maxHeight: '60vh',
@@ -167,7 +167,7 @@ const TracklogImportModal = ({ isVisible, onClose, onImportComplete }) => {
             margin: 0,
             fontSize: '16px',
             fontWeight: '600',
-            color: '#1F2937'
+            color: '#000000c9'
           }}>
             Importar Deriva
           </h3>
@@ -194,7 +194,7 @@ const TracklogImportModal = ({ isVisible, onClose, onImportComplete }) => {
           <div
             ref={dropZoneRef}
             style={{
-              border: `2px dashed ${dragActive ? '#3B82F6' : '#D1D5DB'}`,
+              border: `2px dashed ${dragActive ? '#4e4e86' : 'rgba(78,78,134,0.22)'}`,
               borderRadius: '12px',
               padding: '24px 16px',
               textAlign: 'center',
@@ -208,12 +208,12 @@ const TracklogImportModal = ({ isVisible, onClose, onImportComplete }) => {
             onDrop={handleDrop}
             onClick={() => fileInputRef.current?.click()}
           >
-            <Upload size={36} color={dragActive ? '#3B82F6' : '#6B7280'} style={{ marginBottom: '12px' }} />
+            <Upload size={36} color={dragActive ? '#4e4e86' : '#6B7280'} style={{ marginBottom: '12px' }} />
             <p style={{
               margin: '0 0 8px 0',
               fontSize: '14px',
               fontWeight: '500',
-              color: '#1F2937'
+              color: '#000000c9'
             }}>
               Selecciona un archivo .zip
             </p>
@@ -244,14 +244,14 @@ const TracklogImportModal = ({ isVisible, onClose, onImportComplete }) => {
             }}>
               <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                 {validationResult.valid ? (
-                  <CheckCircle size={20} color="#10B981" />
+                  <CheckCircle size={20} color="#9dc04cd4" />
                 ) : (
-                  <AlertCircle size={20} color="#EF4444" />
+                  <AlertCircle size={20} color="#c24a6e" />
                 )}
                 <span style={{
                   fontSize: '14px',
                   fontWeight: '600',
-                  color: validationResult.valid ? '#10B981' : '#EF4444'
+                  color: validationResult.valid ? '#9dc04cd4' : '#c24a6e'
                 }}>
                   {validationResult.valid ? 'Archivo válido' : 'Error de validación'}
                 </span>
@@ -277,7 +277,7 @@ const TracklogImportModal = ({ isVisible, onClose, onImportComplete }) => {
                 margin: '0 0 16px 0',
                 fontSize: '16px',
                 fontWeight: '600',
-                color: '#1F2937'
+                color: '#000000c9'
               }}>
                 ⚙️ Opciones de Importación
               </h4>
@@ -290,7 +290,7 @@ const TracklogImportModal = ({ isVisible, onClose, onImportComplete }) => {
                   gap: '8px',
                   fontSize: '14px',
                   fontWeight: '500',
-                  color: '#374151',
+                  color: 'rgb(1 9 2 / 84%)',
                   cursor: 'pointer'
                 }}>
                   <input
@@ -311,10 +311,10 @@ const TracklogImportModal = ({ isVisible, onClose, onImportComplete }) => {
                   padding: '16px',
                   backgroundColor: '#F9FAFB',
                   borderRadius: '8px',
-                  border: '1px solid #E5E7EB'
+                  border: '1px solid rgba(78,78,134,0.15)'
                 }}>
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '12px' }}>
-                    <span style={{ fontSize: '14px', fontWeight: '600', color: '#374151' }}>
+                    <span style={{ fontSize: '14px', fontWeight: '600', color: 'rgb(1 9 2 / 84%)' }}>
                       Transformación de Ubicación
                     </span>
                     <button
@@ -352,7 +352,7 @@ const TracklogImportModal = ({ isVisible, onClose, onImportComplete }) => {
                         style={{
                           flex: 1,
                           padding: '8px',
-                          border: '1px solid #D1D5DB',
+                          border: '1px solid rgba(78,78,134,0.22)',
                           borderRadius: '4px',
                           fontSize: '12px'
                         }}
@@ -369,7 +369,7 @@ const TracklogImportModal = ({ isVisible, onClose, onImportComplete }) => {
                         style={{
                           flex: 1,
                           padding: '8px',
-                          border: '1px solid #D1D5DB',
+                          border: '1px solid rgba(78,78,134,0.22)',
                           borderRadius: '4px',
                           fontSize: '12px'
                         }}
@@ -393,7 +393,7 @@ const TracklogImportModal = ({ isVisible, onClose, onImportComplete }) => {
                       style={{
                         width: '100%',
                         padding: '8px',
-                        border: '1px solid #D1D5DB',
+                        border: '1px solid rgba(78,78,134,0.22)',
                         borderRadius: '4px',
                         fontSize: '12px'
                       }}
@@ -416,7 +416,7 @@ const TracklogImportModal = ({ isVisible, onClose, onImportComplete }) => {
                       style={{
                         width: '100%',
                         padding: '8px',
-                        border: '1px solid #D1D5DB',
+                        border: '1px solid rgba(78,78,134,0.22)',
                         borderRadius: '4px',
                         fontSize: '12px'
                       }}
@@ -440,7 +440,7 @@ const TracklogImportModal = ({ isVisible, onClose, onImportComplete }) => {
                       style={{
                         width: '100%',
                         padding: '8px',
-                        border: '1px solid #D1D5DB',
+                        border: '1px solid rgba(78,78,134,0.22)',
                         borderRadius: '4px',
                         fontSize: '12px'
                       }}
@@ -463,26 +463,26 @@ const TracklogImportModal = ({ isVisible, onClose, onImportComplete }) => {
                 <div style={{
                   width: '16px',
                   height: '16px',
-                  border: '2px solid #E5E7EB',
-                  borderTop: '2px solid #3B82F6',
+                  border: '2px solid rgba(78,78,134,0.15)',
+                  borderTop: '2px solid #4e4e86',
                   borderRadius: '50%',
                   animation: 'spin 1s linear infinite'
                 }} />
-                <span style={{ fontSize: '14px', color: '#374151' }}>
+                <span style={{ fontSize: '14px', color: 'rgb(1 9 2 / 84%)' }}>
                   Importando tracklog...
                 </span>
               </div>
               <div style={{
                 width: '100%',
                 height: '4px',
-                backgroundColor: '#E5E7EB',
+                backgroundColor: 'rgba(78,78,134,0.15)',
                 borderRadius: '2px',
                 overflow: 'hidden'
               }}>
                 <div style={{
                   width: `${importProgress}%`,
                   height: '100%',
-                  backgroundColor: '#3B82F6',
+                  backgroundColor: '#4e4e86',
                   transition: 'width 0.3s ease'
                 }} />
               </div>
@@ -500,14 +500,14 @@ const TracklogImportModal = ({ isVisible, onClose, onImportComplete }) => {
             }}>
               <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                 {importResult.success ? (
-                  <CheckCircle size={20} color="#10B981" />
+                  <CheckCircle size={20} color="#9dc04cd4" />
                 ) : (
-                  <AlertCircle size={20} color="#EF4444" />
+                  <AlertCircle size={20} color="#c24a6e" />
                 )}
                 <span style={{
                   fontSize: '14px',
                   fontWeight: '600',
-                  color: importResult.success ? '#10B981' : '#EF4444'
+                  color: importResult.success ? '#9dc04cd4' : '#c24a6e'
                 }}>
                   {importResult.success ? 'Importación exitosa' : 'Error de importación'}
                 </span>
@@ -543,7 +543,7 @@ const TracklogImportModal = ({ isVisible, onClose, onImportComplete }) => {
               padding: '10px',
               border: 'none',
               borderRadius: '8px',
-              backgroundColor: !validationResult?.valid || isImporting ? '#9CA3AF' : '#10B981',
+              backgroundColor: !validationResult?.valid || isImporting ? '#9CA3AF' : '#9dc04cd4',
               color: 'white',
               fontSize: '14px',
               fontWeight: '500',
@@ -563,8 +563,8 @@ const TracklogImportModal = ({ isVisible, onClose, onImportComplete }) => {
             style={{
               padding: '10px 16px',
               backgroundColor: 'white',
-              color: '#374151',
-              border: '1px solid #D1D5DB',
+              color: 'rgb(1 9 2 / 84%)',
+              border: '1px solid rgba(78,78,134,0.22)',
               borderRadius: '8px',
               fontSize: '14px',
               cursor: isImporting ? 'not-allowed' : 'pointer',

--- a/src/hooks/useDraggable.js
+++ b/src/hooks/useDraggable.js
@@ -1,0 +1,44 @@
+import { useState, useCallback, useRef } from 'react';
+
+export default function useDraggable() {
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const dragging = useRef(false);
+  const startPos = useRef({ x: 0, y: 0 });
+  const startOffset = useRef({ x: 0, y: 0 });
+
+  const handlePointerDown = useCallback((e) => {
+    // Only primary button
+    if (e.button !== 0) return;
+    dragging.current = true;
+    startPos.current = { x: e.clientX, y: e.clientY };
+    startOffset.current = { ...position };
+    e.currentTarget.setPointerCapture(e.pointerId);
+    e.currentTarget.style.cursor = 'grabbing';
+
+    const target = e.currentTarget;
+
+    const handlePointerMove = (ev) => {
+      if (!dragging.current) return;
+      const dx = ev.clientX - startPos.current.x;
+      const dy = ev.clientY - startPos.current.y;
+      setPosition({
+        x: startOffset.current.x + dx,
+        y: startOffset.current.y + dy
+      });
+    };
+
+    const handlePointerUp = () => {
+      dragging.current = false;
+      target.style.cursor = 'grab';
+      document.removeEventListener('pointermove', handlePointerMove);
+      document.removeEventListener('pointerup', handlePointerUp);
+    };
+
+    document.addEventListener('pointermove', handlePointerMove);
+    document.addEventListener('pointerup', handlePointerUp);
+  }, [position]);
+
+  const resetPosition = useCallback(() => setPosition({ x: 0, y: 0 }), []);
+
+  return { position, handlePointerDown, resetPosition };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -498,6 +498,33 @@ button,
   cursor: pointer;
 }
 
+/* ── Nature-Tech Palette ── */
+:root {
+  --nt-primary: #4e4e86;
+  --nt-primary-alpha: rgba(78,78,134,0.84);
+  --nt-primary-light: #6a6aad;
+  --nt-success: #9dc04cd4;
+  --nt-success-alpha: rgba(157,192,76,0.83);
+  --nt-success-bg: rgba(157,192,76,0.12);
+  --nt-danger: #c24a6e;
+  --nt-danger-hover: #a83d5a;
+  --nt-danger-alpha-low: rgba(194,74,110,0.4);
+  --nt-danger-alpha-high: rgba(194,74,110,0.8);
+  --nt-text-primary: #000000c9;
+  --nt-text-secondary: rgb(1 9 2 / 84%);
+  --nt-panel-bg: rgba(220,225,235,0.78);
+  --nt-bar-btn-bg: rgba(201,206,177,0.50);
+  --nt-bar-bg: rgba(220,225,235,0.92);
+  --nt-card-bg: #f0f1ec;
+  --nt-card-overlay: rgb(20 50 20 / 35%);
+  --nt-modal-overlay: rgb(20 50 20 / 65%);
+  --nt-detail-gradient: rgb(20 50 20 / 85%);
+  --nt-border-light: rgba(78,78,134,0.15);
+  --nt-border-medium: rgba(78,78,134,0.22);
+  --nt-shadow: rgba(78,78,134,0.18);
+  --nt-shadow-panel: rgba(78,78,134,0.25);
+}
+
 table {
   border-collapse: collapse;
 }
@@ -28708,23 +28735,23 @@ table {
 
 /* Custom marker styles */
 .marker {
-  background-color: #4f46e5;
+  background-color: var(--nt-primary);
   border: 2px solid #fff;
   border-radius: 50%;
   cursor: pointer;
   width: 20px;
   height: 20px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+  box-shadow: 0 2px 4px var(--nt-shadow);
 }
 
 .marker.selected {
-  background-color: #dc2626;
+  background-color: var(--nt-danger);
   border-color: #fef2f2;
   transform: scale(1.2);
 }
 
 .marker.results {
-  background-color: #059669;
+  background-color: var(--nt-success);
   border-color: #ecfdf5;
   transform: scale(1.1);
 }
@@ -28768,13 +28795,13 @@ table {
 
 @keyframes microphone-pulse {
   0% {
-    box-shadow: 0 0 20px rgba(239, 68, 68, 0.6), 0 4px 12px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 0 20px rgba(194, 74, 110, 0.6), 0 4px 12px var(--nt-shadow);
   }
   50% {
-    box-shadow: 0 0 30px rgba(239, 68, 68, 0.8), 0 4px 12px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 0 30px rgba(194, 74, 110, 0.8), 0 4px 12px var(--nt-shadow);
   }
   100% {
-    box-shadow: 0 0 20px rgba(239, 68, 68, 0.6), 0 4px 12px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 0 20px rgba(194, 74, 110, 0.6), 0 4px 12px var(--nt-shadow);
   }
 }
 
@@ -28786,19 +28813,19 @@ table {
   left: 0 !important;
   right: 0 !important;
   bottom: 0 !important;
-  background-color: rgba(0, 0, 0, 0.5) !important;
+  background-color: var(--nt-modal-overlay) !important;
   display: flex !important;
   align-items: center !important;
   justify-content: center !important;
 }
 
 .location-permission-content {
-  background: white !important;
+  background: var(--nt-card-bg) !important;
   border-radius: 8px !important;
   padding: 24px !important;
   max-width: 400px !important;
   margin: 16px !important;
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04) !important;
+  box-shadow: 0 20px 25px -5px var(--nt-shadow), 0 10px 10px -5px var(--nt-shadow) !important;
   position: relative !important;
   z-index: 10000 !important;
 }
@@ -28811,7 +28838,7 @@ table {
 /* Ensure other components appear above map */
 .gradient {
   z-index: 1000;
-  background: linear-gradient(to top, rgba(0,0,0,0.8) 0%, rgba(0,0,0,0.4) 50%, transparent 100%);
+  background: linear-gradient(to top, var(--nt-detail-gradient) 0%, rgb(20 50 20 / 40%) 50%, transparent 100%);
 }
 
 /* TopBar positioning */
@@ -28819,40 +28846,27 @@ table {
   z-index: 1001;
 }
 
-/* Leaflet attribution — compact dark */
-.leaflet-control-attribution {
-  font-size: 7px !important;
-  padding: 1px 4px !important;
-  line-height: 1.2 !important;
-  background: rgba(0, 0, 0, 0.45) !important;
-  color: rgba(255, 255, 255, 0.7) !important;
-  border-radius: 4px 0 0 0 !important;
-}
-.leaflet-control-attribution a {
-  color: rgba(255, 255, 255, 0.8) !important;
-}
-
 /* Leaflet Layer Control Styling */
 .leaflet-control-layers {
-  background: white !important;
-  border: 2px solid rgba(0,0,0,0.2) !important;
+  background: var(--nt-card-bg) !important;
+  border: 2px solid var(--nt-border-light) !important;
   border-radius: 4px !important;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.2) !important;
+  box-shadow: 0 2px 4px var(--nt-shadow) !important;
   padding: 8px !important;
 }
 
 .leaflet-control-layers-toggle {
-  background: white !important;
-  border: 2px solid rgba(0,0,0,0.2) !important;
+  background: var(--nt-card-bg) !important;
+  border: 2px solid var(--nt-border-light) !important;
   border-radius: 4px !important;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.2) !important;
+  box-shadow: 0 2px 4px var(--nt-shadow) !important;
 }
 
 .leaflet-control-layers-expanded {
-  background: white !important;
-  border: 2px solid rgba(0,0,0,0.2) !important;
+  background: var(--nt-card-bg) !important;
+  border: 2px solid var(--nt-border-light) !important;
   border-radius: 4px !important;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.2) !important;
+  box-shadow: 0 2px 4px var(--nt-shadow) !important;
   padding: 8px !important;
   min-width: 200px !important;
 }
@@ -28870,12 +28884,12 @@ table {
 
 /* Microphone icon styling */
 .microphone-button {
-  background: #ef4444 !important;
+  background: var(--nt-danger) !important;
   color: white !important;
   border: 2px solid white !important;
   border-radius: 50% !important;
   padding: 8px !important;
-  box-shadow: 0 4px 8px rgba(0,0,0,0.3) !important;
+  box-shadow: 0 4px 8px var(--nt-shadow) !important;
   transition: all 0.3s ease !important;
 }
 
@@ -28914,22 +28928,22 @@ table {
 @keyframes microphone-pulse {
   0% {
     transform: translate(-50%, 50%) scale(1);
-    box-shadow: 0 8px 25px rgba(239, 68, 68, 0.5), 0 4px 15px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 8px 25px rgba(194, 74, 110, 0.5), 0 4px 15px var(--nt-shadow);
   }
   50% {
     transform: translate(-50%, 50%) scale(1.05);
-    box-shadow: 0 12px 35px rgba(239, 68, 68, 0.7), 0 6px 20px rgba(0, 0, 0, 0.4);
+    box-shadow: 0 12px 35px rgba(194, 74, 110, 0.7), 0 6px 20px var(--nt-shadow);
   }
   100% {
     transform: translate(-50%, 50%) scale(1);
-    box-shadow: 0 8px 25px rgba(239, 68, 68, 0.5), 0 4px 15px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 8px 25px rgba(194, 74, 110, 0.5), 0 4px 15px var(--nt-shadow);
   }
 }
 
 .microphone-button:hover {
-  background: #dc2626 !important;
+  background: var(--nt-danger-hover) !important;
   transform: scale(1.05) !important;
-  box-shadow: 0 6px 12px rgba(0,0,0,0.4) !important;
+  box-shadow: 0 6px 12px var(--nt-shadow) !important;
 }
 
 .microphone-button svg {
@@ -28940,13 +28954,13 @@ table {
 /* Animation for microphone pulse */
 @keyframes microphone-pulse {
   0% {
-    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.7);
+    box-shadow: 0 0 0 0 rgba(194, 74, 110, 0.7);
   }
   70% {
-    box-shadow: 0 0 0 10px rgba(239, 68, 68, 0);
+    box-shadow: 0 0 0 10px rgba(194, 74, 110, 0);
   }
   100% {
-    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0);
+    box-shadow: 0 0 0 0 rgba(194, 74, 110, 0);
   }
 }
 
@@ -28999,7 +29013,7 @@ table {
   margin: 0 0 12px 0;
   font-size: 18px;
   font-weight: 600;
-  color: #1F2937;
+  color: #000000c9;
   text-align: center;
 }
 
@@ -29019,7 +29033,7 @@ table {
   width: 100%;
   padding: 8px 12px;
   border-radius: 6px;
-  border: 2px solid #D1D5DB;
+  border: 2px solid rgba(78,78,134,0.22);
   font-size: 16px;
   background-color: white;
   cursor: pointer;

--- a/src/services/AudioRecorder.tsx
+++ b/src/services/AudioRecorder.tsx
@@ -3,6 +3,7 @@ import { Mic, Square, Play, Pause, Save, X } from 'lucide-react';
 import audioService from './audioService.js';
 import { VoiceRecorder } from 'capacitor-voice-recorder';
 import breadcrumbService from './breadcrumbService.js';
+import useDraggable from '../hooks/useDraggable.js';
 
 // Custom alert function for Android without localhost text
 const showAlert = (message) => {
@@ -11,21 +12,21 @@ const showAlert = (message) => {
     const overlay = document.createElement('div');
     overlay.style.cssText = `
       position: fixed; top: 0; left: 0; right: 0; bottom: 0;
-      background: rgba(0,0,0,0.7); z-index: 10000;
+      background: rgb(20 50 20 / 65%); z-index: 10000;
       display: flex; align-items: center; justify-content: center;
     `;
 
     const modal = document.createElement('div');
     modal.style.cssText = `
-      background: rgba(255, 255, 255, 0.85); border-radius: 8px; padding: 20px;
+      background: rgba(220,225,235,0.92); border-radius: 8px; padding: 20px;
       max-width: 300px; margin: 20px; text-align: center;
       box-shadow: 0 10px 30px rgba(0,0,0,0.3);
     `;
 
     modal.innerHTML = `
-      <p style="margin: 0 0 15px 0; font-size: 14px; color: #374151;">${message}</p>
+      <p style="margin: 0 0 15px 0; font-size: 14px; color: rgb(1 9 2 / 84%);">${message}</p>
       <button style="
-        background: #3B82F6; color: white; border: none; border-radius: 6px;
+        background: #4e4e86; color: white; border: none; border-radius: 6px;
         padding: 8px 16px; cursor: pointer; font-size: 14px;
       ">OK</button>
     `;
@@ -142,6 +143,7 @@ const AudioRecorder = ({
   const [nativeRecordingPath, setNativeRecordingPath] = useState<string | null>(null);
   const [audioBlob, setAudioBlob] = useState<Blob | null>(null);
 
+  const { position: dragPos, handlePointerDown: onDragStart } = useDraggable();
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -581,14 +583,14 @@ const AudioRecorder = ({
       position: 'fixed',
       bottom: '190px',
       left: '50%',
-      transform: 'translateX(-50%)',
+      transform: `translate(calc(-50% + ${dragPos.x}px), ${dragPos.y}px)`,
       zIndex: 999999,
       pointerEvents: 'auto'
     }}>
       <div style={{
-        backgroundColor: '#ffffffbf',
+        backgroundColor: 'rgba(220,225,235,0.78)',
         borderRadius: '16px',
-        boxShadow: 'rgb(157 58 58 / 30%) 0px 10px 30px',
+        boxShadow: 'rgba(78,78,134,0.25) 0px 10px 30px',
         padding: '20px',
         minWidth: '300px',
         maxWidth: '400px',
@@ -597,16 +599,20 @@ const AudioRecorder = ({
         overflow: 'auto',
         position: 'relative'
       }}>
-        <div style={{
+        <div
+          onPointerDown={onDragStart}
+          style={{
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
-          marginBottom: '16px'
+          marginBottom: '16px',
+          cursor: 'grab',
+          touchAction: 'none'
         }}>
           <h3 style={{
             fontSize: '18px',
             fontWeight: '600',
-            color: '#374151',
+            color: 'rgb(1 9 2 / 84%)',
             margin: 0
           }}>
             {isRecording ? 'Recording...' : nativeRecordingPath ? 'Review Recording' : 'Audio Recorder'}
@@ -624,7 +630,7 @@ const AudioRecorder = ({
               style={{
                 color: '#6B7280',
                 backgroundColor: 'transparent',
-                border: '1px solid #D1D5DB',
+                border: '1px solid rgba(78,78,134,0.22)',
                 borderRadius: '4px',
                 cursor: 'pointer',
                 padding: '4px 8px',
@@ -677,16 +683,16 @@ const AudioRecorder = ({
 
         {showLogViewer && (
           <div style={{ margin: '16px 0' }}>
-            <label style={{ fontWeight: 600, color: '#374151', marginBottom: 4, display: 'block' }}>Audio Debug Log (copy below):</label>
+            <label style={{ fontWeight: 600, color: 'rgb(1 9 2 / 84%)', marginBottom: 4, display: 'block' }}>Audio Debug Log (copy below):</label>
             <textarea
               value={logText}
               readOnly
-              style={{ width: '100%', minHeight: 200, fontFamily: 'monospace', fontSize: 12, color: '#111827', background: '#F3F4F6', border: '1px solid #D1D5DB', borderRadius: 4, padding: 8, marginBottom: 8 }}
+              style={{ width: '100%', minHeight: 200, fontFamily: 'monospace', fontSize: 12, color: '#000000c9', background: '#F3F4F6', border: '1px solid rgba(78,78,134,0.22)', borderRadius: 4, padding: 8, marginBottom: 8 }}
               onFocus={e => e.target.select()}
             />
             <button
               onClick={() => setShowLogViewer(false)}
-              style={{ color: '#EF4444', background: 'transparent', border: 'none', cursor: 'pointer', fontSize: 14 }}
+              style={{ color: '#c24a6e', background: 'transparent', border: 'none', cursor: 'pointer', fontSize: 14 }}
             >
               Close Log Viewer
             </button>
@@ -698,7 +704,7 @@ const AudioRecorder = ({
           <div style={{
             fontSize: '24px',
             fontFamily: 'monospace',
-            color: '#374151',
+            color: 'rgb(1 9 2 / 84%)',
             marginBottom: '8px'
           }}>
             {formatTime(recordingTime)}
@@ -708,7 +714,7 @@ const AudioRecorder = ({
           {recordingTime > 0 && (
             <div style={{
               fontSize: '12px',
-              color: recordingTime >= 540 ? '#EF4444' : recordingTime >= 480 ? '#F59E0B' : '#6B7280',
+              color: recordingTime >= 540 ? '#c24a6e' : recordingTime >= 480 ? '#F59E0B' : '#6B7280',
               marginBottom: '4px'
             }}>
               {recordingTime >= 600 ? '⏹ Máximo 10 min alcanzado' :
@@ -727,13 +733,13 @@ const AudioRecorder = ({
               <div style={{
                 width: '12px',
                 height: '12px',
-                backgroundColor: recordingTime >= 540 ? '#EF4444' : '#10B981',
+                backgroundColor: recordingTime >= 540 ? '#c24a6e' : '#9dc04cd4',
                 borderRadius: '50%',
                 animation: 'pulse 1s infinite'
               }}></div>
               <span style={{
                 fontSize: '14px',
-                color: recordingTime >= 540 ? '#EF4444' : '#6B7280'
+                color: recordingTime >= 540 ? '#c24a6e' : '#6B7280'
               }}>
                 {recordingTime >= 540 ? 'Se detendrá pronto' : 'Grabando...'}
               </span>
@@ -762,7 +768,7 @@ const AudioRecorder = ({
                 justifyContent: 'center',
                 width: '64px',
                 height: '64px',
-                backgroundColor: userLocation ? '#EF4444' : '#9CA3AF',
+                backgroundColor: userLocation ? '#c24a6e' : '#9CA3AF',
                 color: 'white',
                 border: 'none',
                 borderRadius: '50%',
@@ -804,7 +810,7 @@ const AudioRecorder = ({
                 justifyContent: 'center',
                 width: '48px',
                 height: '48px',
-                backgroundColor: '#3B82F6',
+                backgroundColor: '#4e4e86',
                 color: 'white',
                 border: 'none',
                 borderRadius: '50%',
@@ -843,7 +849,7 @@ const AudioRecorder = ({
                 display: 'block',
                 fontSize: '14px',
                 fontWeight: '500',
-                color: '#374151',
+                color: 'rgb(1 9 2 / 84%)',
                 marginBottom: '4px'
               }}>
                 Nota (opcional)
@@ -856,7 +862,7 @@ const AudioRecorder = ({
                 style={{
                   width: '100%',
                   padding: '8px 12px',
-                  border: '1px solid #D1D5DB',
+                  border: '1px solid rgba(78,78,134,0.22)',
                   borderRadius: '6px',
                   fontSize: '14px',
                   outline: 'none',
@@ -871,7 +877,7 @@ const AudioRecorder = ({
               onClick={() => setShowDetailedFields(!showDetailedFields)}
               style={{
                 background: 'none',
-                border: '1px solid #D1D5DB',
+                border: '1px solid rgba(78,78,134,0.22)',
                 borderRadius: '6px',
                 padding: '6px 12px',
                 fontSize: '13px',
@@ -894,7 +900,7 @@ const AudioRecorder = ({
                 display: 'block',
                 fontSize: '14px',
                 fontWeight: '500',
-                color: '#374151',
+                color: 'rgb(1 9 2 / 84%)',
                 marginBottom: '4px'
               }}>
                 Nombre del archivo
@@ -907,7 +913,7 @@ const AudioRecorder = ({
                 style={{
                   width: '100%',
                   padding: '8px 12px',
-                  border: '1px solid #D1D5DB',
+                  border: '1px solid rgba(78,78,134,0.22)',
                   borderRadius: '6px',
                   fontSize: '14px',
                   outline: 'none',
@@ -922,7 +928,7 @@ const AudioRecorder = ({
                   display: 'block',
                   fontSize: '14px',
                   fontWeight: '500',
-                  color: '#374151',
+                  color: 'rgb(1 9 2 / 84%)',
                   marginBottom: '4px'
                 }}>
                   Clima
@@ -933,7 +939,7 @@ const AudioRecorder = ({
                   style={{
                     width: '100%',
                     padding: '8px 12px',
-                    border: '1px solid #D1D5DB',
+                    border: '1px solid rgba(78,78,134,0.22)',
                     borderRadius: '6px',
                     fontSize: '14px',
                     outline: 'none',
@@ -954,7 +960,7 @@ const AudioRecorder = ({
                   display: 'block',
                   fontSize: '14px',
                   fontWeight: '500',
-                  color: '#374151',
+                  color: 'rgb(1 9 2 / 84%)',
                   marginBottom: '4px'
                 }}>
                   Temperatura
@@ -965,7 +971,7 @@ const AudioRecorder = ({
                   style={{
                     width: '100%',
                     padding: '8px 12px',
-                    border: '1px solid #D1D5DB',
+                    border: '1px solid rgba(78,78,134,0.22)',
                     borderRadius: '6px',
                     fontSize: '14px',
                     outline: 'none',
@@ -988,7 +994,7 @@ const AudioRecorder = ({
                   display: 'block',
                   fontSize: '14px',
                   fontWeight: '500',
-                  color: '#374151',
+                  color: 'rgb(1 9 2 / 84%)',
                   marginBottom: '8px'
                 }}>
                   Especies
@@ -1000,7 +1006,7 @@ const AudioRecorder = ({
                   maxHeight: '150px',
                   overflowY: 'auto',
                   padding: '8px',
-                  border: '1px solid #D1D5DB',
+                  border: '1px solid rgba(78,78,134,0.22)',
                   borderRadius: '6px',
                   backgroundColor: '#F9FAFB'
                 }}>
@@ -1040,7 +1046,7 @@ const AudioRecorder = ({
                   display: 'block',
                   fontSize: '14px',
                   fontWeight: '500',
-                  color: '#374151',
+                  color: 'rgb(1 9 2 / 84%)',
                   marginBottom: '4px'
                 }}>
                   Calidad
@@ -1051,7 +1057,7 @@ const AudioRecorder = ({
                   style={{
                     width: '100%',
                     padding: '8px 12px',
-                    border: '1px solid #D1D5DB',
+                    border: '1px solid rgba(78,78,134,0.22)',
                     borderRadius: '6px',
                     fontSize: '14px',
                     outline: 'none',
@@ -1076,7 +1082,7 @@ const AudioRecorder = ({
                   alignItems: 'center',
                   justifyContent: 'center',
                   gap: '8px',
-                  backgroundColor: '#10B981',
+                  backgroundColor: '#9dc04cd4',
                   color: 'white',
                   padding: '8px 16px',
                   border: 'none',
@@ -1096,9 +1102,9 @@ const AudioRecorder = ({
                   alignItems: 'center',
                   justifyContent: 'center',
                   padding: '8px 16px',
-                  border: '1px solid #D1D5DB',
+                  border: '1px solid rgba(78,78,134,0.22)',
                   borderRadius: '6px',
-                  color: '#374151',
+                  color: 'rgb(1 9 2 / 84%)',
                   backgroundColor: 'white',
                   cursor: 'pointer',
                   fontSize: '14px',

--- a/src/services/breadcrumbService.js
+++ b/src/services/breadcrumbService.js
@@ -383,7 +383,10 @@ class BreadcrumbService {
 
       const dx = point.lat - xx;
       const dy = point.lng - yy;
-      return Math.sqrt(dx * dx + dy * dy);
+      // Convert degree distance to approximate meters
+      const latToMeters = 111111;
+      const lngToMeters = 111111 * Math.cos((point.lat * Math.PI) / 180);
+      return Math.sqrt((dx * latToMeters) ** 2 + (dy * lngToMeters) ** 2);
     };
 
     const douglasPeucker = (points, tolerance) => {
@@ -413,7 +416,18 @@ class BreadcrumbService {
       }
     };
 
-    return douglasPeucker(breadcrumbs, tolerance);
+    const compressed = douglasPeucker(breadcrumbs, tolerance);
+    // Minimum point guarantee to prevent degenerate cases
+    if (compressed.length < Math.min(20, breadcrumbs.length)) {
+      const step = Math.max(1, Math.floor(breadcrumbs.length / 20));
+      const sampled = [breadcrumbs[0]];
+      for (let i = step; i < breadcrumbs.length - 1; i += step) {
+        sampled.push(breadcrumbs[i]);
+      }
+      sampled.push(breadcrumbs[breadcrumbs.length - 1]);
+      return sampled;
+    }
+    return compressed;
   }
 
   // Export breadcrumbs in different formats

--- a/src/utils/recordingExporter.js
+++ b/src/utils/recordingExporter.js
@@ -23,9 +23,9 @@ const showAlert = (message) => {
     `;
     
     modal.innerHTML = `
-      <p style="margin: 0 0 15px 0; font-size: 14px; color: #374151;">${message}</p>
+      <p style="margin: 0 0 15px 0; font-size: 14px; color: rgb(1 9 2 / 84%);">${message}</p>
       <button style="
-        background: #3B82F6; color: white; border: none; border-radius: 6px;
+        background: #4e4e86; color: white; border: none; border-radius: 6px;
         padding: 8px 16px; cursor: pointer; font-size: 14px;
       ">OK</button>
     `;


### PR DESCRIPTION
…acklines, UX nature-tech palette

- Map zoom 16→15 (~1km around marker) for initial view, auto-center, and refresh
- Per-derive golden-angle color distribution instead of per-user alias colors
- Thicker/more opaque session tracklines with color dot in tooltips
- Nature-tech color palette across UI (buttons, modals, player, alerts)
- Draggable audio player, Jamm mode leader-loop fix, proximity volume toggle
- Esri + CyclOSM tile layers, attribution control off